### PR TITLE
Fix a bug in xref64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 kernel_caches/
 bin/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Patches written by myself are included here. These include patches from async_wa
 This fork includes a testing portion, allowing us to confirm that the results returned from the patchfinder are valid.
 
 To run the tests, you must do the following:
-1. Run `./fetch_kerncaches`, or run `python ./fetch_kerncaches`. **Please note this will download 8 iOS versions**, and extract and decompress the kernelcaches. You can change which versions of iOS are to be downloaded in the file.
+1. Run `./fetch_kerncaches`, or run `python ./fetch_kerncaches`. **Please note this will download 13 iOS versions**, and extract and decompress the kernelcaches. You can change which versions of iOS are to be downloaded in the file.
 2. Run `make patchfinder64`
 3. Run `python test_versions.py`
 

--- a/fetch_kerncaches
+++ b/fetch_kerncaches
@@ -16,7 +16,7 @@ ipsw_urls = {}
 for ipsw in ipsw_list:
     ipsw_urls[ipsw["version"]] = ipsw["url"]
 
-intended_firmwares = ["11.0", "11.0.3", "11.1", "11.1.2", "11.2", "11.2.6", "11.3.1", "11.4.1", "12.0", "12.0", "12.0.1", "12.0.2", "12.1", "12.1.1"]
+intended_firmwares = ["11.0", "11.0.3", "11.1", "11.1.2", "11.2", "11.2.6", "11.3.1", "11.4.1", "12.0", "12.0.1", "12.0.2", "12.1", "12.1.1"]
 
 # Translated from BootX-81//bootx.tproj/sl.subproj/lzss.c
 N = 4096

--- a/fetch_kerncaches
+++ b/fetch_kerncaches
@@ -16,7 +16,7 @@ ipsw_urls = {}
 for ipsw in ipsw_list:
     ipsw_urls[ipsw["version"]] = ipsw["url"]
 
-intended_firmwares = ["11.0", "11.0.3", "11.1", "11.1.2", "11.2", "11.2.6", "11.3.1", "11.4.1"]
+intended_firmwares = ["11.0", "11.0.3", "11.1", "11.1.2", "11.2", "11.2.6", "11.3.1", "11.4.1", "12.0", "12.0", "12.0.1", "12.0.2", "12.1", "12.1.1"]
 
 # Translated from BootX-81//bootx.tproj/sl.subproj/lzss.c
 N = 4096

--- a/patchfinder64.c
+++ b/patchfinder64.c
@@ -235,7 +235,7 @@ bof64(const uint8_t *buf, addr_t start, addr_t where)
             if ((delta & 0xF) == 0) {
                 addr_t prev = where - ((delta >> 4) + 1) * 4;
                 uint32_t au = *(uint32_t *)(buf + prev);
-                if ((au & 0xFFC003E0) == 0xA98003E0) {
+                if ((au & 0x3BC003E0) == 0x298003E0) {
                     //printf("%x: STP x, y, [SP,#-imm]!\n", prev);
                     return prev;
                 }

--- a/patchfinder64.c
+++ b/patchfinder64.c
@@ -600,7 +600,7 @@ init_kernel(addr_t base, const char *filename)
 void
 term_kernel(void)
 {
-    free(kernel);
+    if (kernel != NULL) free(kernel);
 }
 
 /* these operate on VA ******************************************************/

--- a/patchfinder64.c
+++ b/patchfinder64.c
@@ -1258,6 +1258,9 @@ addr_t find_vnode_lookup(void) {
 
 addr_t find_vnode_put(void) {
     addr_t err_str = find_strref("KBY: getparent(%p) != parent_vp(%p)", 1, 1);
+    if (err_str == 0)
+	    err_str = find_strref("getparent(%p) != parent_vp(%p)", 1, 1);
+
     err_str -= kerndumpbase;
 
     addr_t call_to_os_log = step64(kernel, err_str, 20*4, INSN_CALL);

--- a/patchfinder64.c
+++ b/patchfinder64.c
@@ -239,6 +239,17 @@ bof64(const uint8_t *buf, addr_t start, addr_t where)
                     //printf("%x: STP x, y, [SP,#-imm]!\n", prev);
                     return prev;
                 }
+                for (addr_t diff = 4; diff < delta/4+4; diff+=4) {
+                    uint32_t ai = *(uint32_t *)(buf + where - diff);
+                    // SUB SP, SP, #imm
+                    if ((ai&0xFFC003FF) == 0xD10003FF) {
+                        return where - diff;
+                    }
+                    // Not stp and not str
+                    if (((ai & 0xFFC003E0) != 0xA90003E0) && (ai&0xFFC001F0) != 0xF90001E0) {
+                        break;
+                    }
+                }
             }
         }
     }

--- a/patchfinder64.c
+++ b/patchfinder64.c
@@ -1723,6 +1723,10 @@ main(int argc, char **argv)
     addr_t actual_offset = find_symbol(symbol_name); \
     printf("%s: PF=0x%llx - AS=0x%llx - %s\n", symbol_name, patchfinder_offset, actual_offset, (patchfinder_offset == actual_offset ? "PASS" : "FAIL")); \
 } while(0)
+#define FIND(name) do { \
+    addr_t patchfinder_offset = find_ ##name (); \
+    printf("%s: PF=0x%llx - %s\n", #name, patchfinder_offset, (patchfinder_offset != 0 ? "PASS" : "FAIL")); \
+} while(0)
 
     CHECK(vfs_context_current, "_vfs_context_current");
     CHECK(vnode_lookup, "_vnode_lookup");
@@ -1739,6 +1743,12 @@ main(int argc, char **argv)
     CHECK(lck_mtx_lock, "_lck_mtx_lock");
     CHECK(lck_mtx_unlock, "_lck_mtx_unlock");
     CHECK(strlen, "_strlen");
+    FIND(add_x0_x0_0x40_ret);
+    FIND(zone_map_ref);
+    FIND(OSBoolean_True);
+    FIND(osunserializexml);
+    FIND(smalloc);
+    FIND(shenanigans);
 
     term_kernel();
     return 0;

--- a/patchfinder64.c
+++ b/patchfinder64.c
@@ -638,6 +638,7 @@ term_kernel(void)
 #define INSN_CALL 0x94000000, 0xFC000000
 #define INSN_B    0x14000000, 0xFC000000
 #define INSN_CBZ  0x34000000, 0xFC000000
+#define INSN_ADRP 0x90000000, 0x9F000000
 
 addr_t
 find_register_value(addr_t where, int reg)

--- a/patchfinder64.c
+++ b/patchfinder64.c
@@ -1368,6 +1368,19 @@ addr_t find_strlen(void) {
     return offset_to_target + kerndumpbase;
 }
 
+
+/*
+ *
+ * 
+ *
+ */
+
+/*
+ *
+ * @Cryptiiiic's patches
+ *
+ */ 
+
 addr_t find_boottime(void) {
     addr_t ref = find_strref("%s WARNING: PMU offset is less then sys PMU", 1, string_base_oslstring);
     ref -= kerndumpbase;
@@ -1401,13 +1414,11 @@ addr_t find_boottime(void) {
     return val;
 }
 
-
 /*
  *
  * 
  *
  */
-
 
 
 #ifdef HAVE_MAIN

--- a/patchfinder64.c
+++ b/patchfinder64.c
@@ -120,7 +120,7 @@ static int DecodeBitMasks(unsigned immN, unsigned imms, unsigned immr, int immed
 	if (len < 1) {
 		return -1;
 	}
-	levels = ZeroExtendOnes(len, 6);
+	levels = (unsigned int)ZeroExtendOnes(len, 6);
 	if (immediate && (imms & levels) == levels) {
 		return -1;
 	}

--- a/patchfinder64.c
+++ b/patchfinder64.c
@@ -235,6 +235,11 @@ step64_back(const uint8_t *buf, addr_t start, size_t length, uint32_t what, uint
     return 0;
 }
 
+step_adrp_to_reg(const uint8_t *buf, addr_t start, size_t length, int reg)
+{
+    return step64(buf, start, length, 0x90000000 | (reg&0x1F), 0x9F00001F);
+}
+
 static addr_t
 bof64(const uint8_t *buf, addr_t start, addr_t where)
 {
@@ -1001,7 +1006,7 @@ find_trustcache(void)
         // iOS 12
         ref -= kerndumpbase;
 
-        ref = step64(kernel, ref, 0x200, 0x9000001A, 0x9F00001F);
+        ref = step_adrp_to_reg(kernel, ref, 0x200, 26);
         if (!ref)
             return 0;
 

--- a/patchfinder64.c
+++ b/patchfinder64.c
@@ -257,7 +257,10 @@ xref64(const uint8_t *buf, addr_t start, addr_t end, addr_t what)
     for (i = start & ~3; i < end; i += 4) {
         uint32_t op = *(uint32_t *)(buf + i);
         unsigned reg = op & 0x1F;
+        int op_is_adrp = 0;
+        
         if ((op & 0x9F000000) == 0x90000000) {
+            op_is_adrp = 1;
             signed adr = ((op & 0x60000000) >> 18) | ((op & 0xFFFFE0) << 8);
             //printf("%llx: ADRP X%d, 0x%llx\n", i, reg, ((long long)adr << 1) + (i & ~0xFFF));
             value[reg] = ((long long)adr << 1) + (i & ~0xFFF);
@@ -299,7 +302,7 @@ xref64(const uint8_t *buf, addr_t start, addr_t end, addr_t what)
             //printf("%llx: LDR X%d, =0x%llx\n", i, reg, adr + i);
             value[reg] = adr + i;		// XXX address, not actual value
         }
-        if (value[reg] == what) {
+        if (!op_is_adrp && value[reg] == what) {
             return i;
         }
     }

--- a/patchfinder64.c
+++ b/patchfinder64.c
@@ -1743,6 +1743,7 @@ main(int argc, char **argv)
     CHECK(lck_mtx_lock, "_lck_mtx_lock");
     CHECK(lck_mtx_unlock, "_lck_mtx_unlock");
     CHECK(strlen, "_strlen");
+    FIND(trustcache);
     FIND(add_x0_x0_0x40_ret);
     FIND(zone_map_ref);
     FIND(OSBoolean_True);

--- a/patchfinder64.c
+++ b/patchfinder64.c
@@ -603,7 +603,10 @@ init_kernel(addr_t base, const char *filename)
 void
 term_kernel(void)
 {
-    if (kernel != NULL) free(kernel);
+    if (kernel != NULL) {
+        free(kernel);
+        kernel = NULL;
+    }
 }
 
 /* these operate on VA ******************************************************/

--- a/patchfinder64.c
+++ b/patchfinder64.c
@@ -993,10 +993,48 @@ find_sysbootnonce(void)
 }
 
 addr_t
+find_spinlock_panic(void)
+{
+    addr_t ref = find_strref("\"Spinlock timeout after %llu ticks,", true, false);
+    if (!ref)
+        return 0;
+
+    ref -= kerndumpbase;
+
+    return step64_back(kernel, ref, 0x100, 0xd2800009, 0xffffffff);
+}
+
+addr_t
 find_trustcache(void)
 {
     addr_t cbz, call, func, val;
-    addr_t ref = find_strref("amfi_prevent_old_entitled_platform_binaries", true, true);
+    addr_t ref = find_strref("\"region to unlock not page aligned", true, false);
+    if (ref) {
+        // iOS 12
+        ref -= kerndumpbase;
+
+        addr_t spr = find_spinlock_panic();
+        if (!spr)
+            return 0;
+
+        call = 0;
+        for (int i=0; i<12; i++) {
+            ref = find_call64(kernel, ref + 4, 0x100);
+            if (follow_call64(kernel, ref) == spr) {
+                call = ref;
+                break;
+            }
+        }
+        if (!call)
+            return 0;
+
+        val = calc64(kernel, call + 4, call + 4 * 3, 8);
+        if (!val)
+            return 0;
+
+        return val + kerndumpbase;
+    }
+    ref = find_strref("amfi_prevent_old_entitled_platform_binaries", true, true);
     if (!ref) {
         // iOS 11
         ref = find_strref("com.apple.MobileFileIntegrity", false, true);
@@ -1009,6 +1047,9 @@ find_trustcache(void)
             return 0;
         }
         call = step64(kernel, call + 4, 64, INSN_CALL);
+        if (!call) {
+            return 0;
+        }
         goto okay;
     }
     ref -= kerndumpbase;
@@ -1066,6 +1107,9 @@ okay:
         }
         
         val = calc64(kernel, call, call + 6 * 4, 21);
+        if (!val) {
+            return 0;
+        }
     }
     return val + kerndumpbase;
 }

--- a/patchfinder64.h
+++ b/patchfinder64.h
@@ -43,5 +43,6 @@ uint64_t find_vnode_recycle(void);
 uint64_t find_lck_mtx_lock(void);
 uint64_t find_lck_mtx_unlock(void);
 uint64_t find_strlen(void);
+uint64_t find_boottime(void);
 
 #endif

--- a/patchfinder64.h
+++ b/patchfinder64.h
@@ -28,5 +28,20 @@ uint64_t find_sysbootnonce(void);
 uint64_t find_trustcache(void);
 uint64_t find_amficache(void);
 uint64_t find_allproc(void);
+uint64_t find_vfs_context_current(void);
+uint64_t find_vnode_lookup(void);
+uint64_t find_vnode_put(void);
+uint64_t find_vnode_getfromfd(void);
+uint64_t find_vnode_getattr(void);
+uint64_t find_SHA1Init(void);
+uint64_t find_SHA1Update(void);
+uint64_t find_SHA1Final(void);
+uint64_t find_csblob_entitlements_dictionary_set(void);
+uint64_t find_kernel_task(void);
+uint64_t find_kernproc(void);
+uint64_t find_vnode_recycle(void);
+uint64_t find_lck_mtx_lock(void);
+uint64_t find_lck_mtx_unlock(void);
+uint64_t find_strlen(void);
 
 #endif

--- a/patchfinder64.h
+++ b/patchfinder64.h
@@ -43,6 +43,12 @@ uint64_t find_vnode_recycle(void);
 uint64_t find_lck_mtx_lock(void);
 uint64_t find_lck_mtx_unlock(void);
 uint64_t find_strlen(void);
+uint64_t find_add_x0_x0_0x40_ret(void);
 uint64_t find_boottime(void);
+uint64_t find_zone_map_ref(void);
+uint64_t find_OSBoolean_True(void);
+uint64_t find_osunserializexml(void);
+uint64_t find_smalloc(void);
+uint64_t find_shenanigans(void);
 
 #endif

--- a/patchfinder64.h
+++ b/patchfinder64.h
@@ -1,7 +1,7 @@
 #ifndef PATCHFINDER64_H_
 #define PATCHFINDER64_H_
 
-int init_kernel(uint64_t base, const char *filename);
+int init_kernel(size_t (*kread)(uint64_t, void *, size_t), uint64_t kernel_base, const char *filename);
 void term_kernel(void);
 
 enum { SearchInCore, SearchInPrelink };


### PR DESCRIPTION
Fixes a bug in xref64 that would cause it to return the first ADRP in the same page as xref if the xref being searched for had a PAGEOFF of 0